### PR TITLE
Rebuild without libuuid in deps & add pyyaml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - plugins_path.patch  # [linux]
 
 build:
-  number: 2
+  number: 3
   skip: true  # [not linux or py3k]
 
 requirements:
@@ -80,6 +80,7 @@ requirements:
     - pygments
     - pytz
     - six
+    - pyyaml
     - yaml
 
 # test:


### PR DESCRIPTION
Qt and GDAL (via libdap4) from feedstocks no longer use libuuid feedstock. Having just one of these deps use libuuid was causing compilation and runtime issues for QGIS
when mixing libuuid sources. See https://github.com/conda-forge/libdap4-feedstock/pull/9

This commit also adds pyyaml, a dependency of `processing` plugin missing from the runtime dependency list.