### PR TITLE
New version! 2.18.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "qgis" %}
-{% set version = "2.16.3" %}
-{% set md5 = "50a1799c6eb8c90eeeda4affedeea49c" %}
+{% set version = "2.18.0" %}
+{% set md5 = "861c4af53113158581b42df2acbc3773" %}
 
 
 package:
@@ -17,7 +17,7 @@ source:
     - plugins_path.patch  # [linux]
 
 build:
-  number: 3
+  number: 0
   skip: true  # [not linux or py3k]
 
 requirements:


### PR DESCRIPTION
Version 2.18.0 has been released. This is the last version in the 2.x series before QGIS 3.0 is released in Q1 2017.

Visual changelog: http://changelog.qgis.org/en/qgis/version/2.18.0/