### PR TITLE
Reenable OSX for 3.6 post QCA fix

### DIFF
--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -1,0 +1,67 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '4'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '4'
+expat:
+- '2.2'
+gdal:
+- '2.4'
+geos:
+- 3.7.1
+gsl:
+- '2.4'
+icu:
+- '58'
+libspatialindex:
+- '1.9'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+pin_run_as_build:
+  expat:
+    max_pin: x.x
+  gdal:
+    max_pin: x.x
+  geos:
+    max_pin: x.x.x
+  gsl:
+    max_pin: x.x
+  icu:
+    max_pin: x
+  libspatialindex:
+    max_pin: x.x
+  proj4:
+    max_pin: x.x.x
+  pyqt:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  qt:
+    max_pin: x.x
+  sqlite:
+    max_pin: x
+proj4:
+- 6.1.0
+pyqt:
+- '5.9'
+python:
+- '3.6'
+qt:
+- '5.9'
+sqlite:
+- '3'
+zip_keys:
+- - pyqt
+  - qt

--- a/.ci_support/osx_python3.7.yaml
+++ b/.ci_support/osx_python3.7.yaml
@@ -1,0 +1,67 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '4'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '4'
+expat:
+- '2.2'
+gdal:
+- '2.4'
+geos:
+- 3.7.1
+gsl:
+- '2.4'
+icu:
+- '58'
+libspatialindex:
+- '1.9'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+pin_run_as_build:
+  expat:
+    max_pin: x.x
+  gdal:
+    max_pin: x.x
+  geos:
+    max_pin: x.x.x
+  gsl:
+    max_pin: x.x
+  icu:
+    max_pin: x
+  libspatialindex:
+    max_pin: x.x
+  proj4:
+    max_pin: x.x.x
+  pyqt:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  qt:
+    max_pin: x.x
+  sqlite:
+    max_pin: x
+proj4:
+- 6.1.0
+pyqt:
+- '5.9'
+python:
+- '3.7'
+qt:
+- '5.9'
+sqlite:
+- '3'
+zip_keys:
+- - pyqt
+  - qt

--- a/README.md
+++ b/README.md
@@ -48,6 +48,20 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_python3.6</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4674&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qgis-feedstock?branchName=master&jobName=osx&configuration=osx_python3.6" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_python3.7</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4674&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qgis-feedstock?branchName=master&jobName=osx&configuration=osx_python3.7" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>win_c_compilervs2015cxx_compilervs2015python3.6</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4674&branchName=master">
@@ -65,12 +79,6 @@ Current build status
           </tbody>
         </table>
       </details>
-    </td>
-  </tr>
-  <tr>
-    <td>OSX</td>
-    <td>
-      <img src="https://img.shields.io/badge/OSX-disabled-lightgrey.svg" alt="OSX disabled">
     </td>
   </tr>
 ![ppc64le disabled](https://img.shields.io/badge/ppc64le-disabled-lightgrey.svg)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,4 +4,5 @@
 
 jobs:
   - template: ./.azure-pipelines/azure-pipelines-linux.yml
+  - template: ./.azure-pipelines/azure-pipelines-osx.yml
   - template: ./.azure-pipelines/azure-pipelines-win.yml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,8 @@ source:
     - patches/0006-CMakeLists-providers-MDAL-HDF5.patch  # [win]
     # workaround for QProcess.startDetached working differently in Qt 5.9
     - patches/0007-win-startDetached.patch  # [win]
+    # Fix for building on OSX < 10.14 (__MAC_10_14 is not defined)
+    - patches/0008-mac-dark-theme.patch
 
 build:
   number: 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,8 +26,8 @@ source:
     - patches/0007-win-startDetached.patch  # [win]
 
 build:
-  number: 1
-  skip: true  # [py2k or osx]
+  number: 2
+  skip: true  # [py2k]
 
 requirements:
   build:

--- a/recipe/patches/0008-mac-dark-theme.patch
+++ b/recipe/patches/0008-mac-dark-theme.patch
@@ -1,0 +1,22 @@
+From 508817d6344cb9fb7215209db7994b97ad8c5162 Mon Sep 17 00:00:00 2001
+From: David Marteau <david@innophi.com>
+Date: Tue, 22 Jan 2019 09:28:17 +0100
+Subject: [PATCH] Fix MAC build for OSX < 10.14
+
+---
+ src/native/mac/qgsmacnative.mm | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/native/mac/qgsmacnative.mm b/src/native/mac/qgsmacnative.mm
+index 6d23b16868d..9c35c056b88 100644
+--- a/src/native/mac/qgsmacnative.mm
++++ b/src/native/mac/qgsmacnative.mm
+@@ -121,7 +121,7 @@ - ( BOOL )userNotificationCenter:( NSUserNotificationCenter * )center shouldPres
+ 
+ bool QgsMacNative::hasDarkTheme()
+ {
+-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_14
++#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
+   if ( [NSApp respondsToSelector:@selector( effectiveAppearance )] )
+   {
+     // compiled on macos 10.14+ AND running on macos 10.14+


### PR DESCRIPTION
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Reenables OSX now that QCA has been fixed