### PR TITLE
Fix activate.sh for OSX

### DIFF
--- a/.ci_support/migrations/gdal31.yaml
+++ b/.ci_support/migrations/gdal31.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-gdal:
-- '3.1'
-migrator_ts: 1589741512.6218328

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -45,8 +45,12 @@ fi
 if [ -z "${DOCKER_IMAGE}" ]; then
     SHYAML_INSTALLED="$(shyaml -h || echo NO)"
     if [ "${SHYAML_INSTALLED}" == "NO" ]; then
-        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Falling back to condaforge/linux-anvil-comp7"
-        DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Trying to parse with coreutils"
+        DOCKER_IMAGE=$(cat .ci_support/${CONFIG}.yaml | grep '^docker_image:$' -A 1 | tail -n 1 | cut -b 3-)
+        if [ "${DOCKER_IMAGE}" = "" ]; then
+            echo "No docker_image entry found in ${CONFIG}. Falling back to condaforge/linux-anvil-comp7"
+            DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+        fi
     else
         DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )"
     fi
@@ -64,8 +68,8 @@ fi
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z \
-           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
+           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
     - patches/0007-OSX-no-app.patch  # [osx]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py2k]
 
 requirements:

--- a/recipe/scripts/activate.sh
+++ b/recipe/scripts/activate.sh
@@ -11,24 +11,16 @@ fi
 if [[ -n "$QT_PLUGIN_PATH" ]]; then
     export _CONDA_SET_QT_PLUGIN_PATH=$QT_PLUGIN_PATH
 fi
-# Mac specific
-if [[ -n "$QGIS_BUNDLE" ]]; then
-    export _CONDA_SET_QGIS_BUNDLE=$QGIS_BUNDLE
-fi
-
 
 if [ -d $CONDA_PREFIX/share/qgis/python ]; then
     # Linux only needs to be able to find Python packages
     export PYTHONPATH="$CONDA_PREFIX/share/qgis/python:$PYTHONPATH"
     export PYTHONPATH="$CONDA_PREFIX/share/qgis/python/plugins:$PYTHONPATH"
-elif [ -d $CONDA_PREFIX/QGIS.app ]; then
-    # MacOS
-    # See: https://github.com/OSGeo/homebrew-osgeo4mac/blob/master/Formula/qgis-ltr.rb#L895
-    export QGIS_BUNDLE="$CONDA_PREFIX/QGIS.app/Contents"
-    export QGIS_PREFIX_PATH="$CONDA_PREFIX/QGIS.app/Contents/MacOS"
-    export PYTHONPATH="$CONDA_PREFIX/QGIS.app/Contents/Resources/python:$PYTHONPATH"
-    export PYTHONPATH="$CONDA_PREFIX/QGIS.app/Contents/Resources/python/plugins:$PYTHONPATH"
-    export QT_PLUGIN_PATH="$CONDA_PREFIX/plugins:$QT_PLUGIN_PATH"
+    if [ -d $CONDA_PREFIX/QGIS.app ]; then
+        # OSX also needs these
+        export QGIS_PREFIX_PATH="$CONDA_PREFIX"
+        export QT_PLUGIN_PATH="$CONDA_PREFIX/plugins:$QT_PLUGIN_PATH"
+    fi
 elif [ -d $CONDA_PREFIX/Library/python ]; then
     # On Windows
     # See: https://github.com/qgis/QGIS/blob/master/ms-windows/osgeo4w/qgis.vars

--- a/recipe/scripts/activate.sh
+++ b/recipe/scripts/activate.sh
@@ -13,14 +13,12 @@ if [[ -n "$QT_PLUGIN_PATH" ]]; then
 fi
 
 if [ -d $CONDA_PREFIX/share/qgis/python ]; then
-    # Linux only needs to be able to find Python packages
+    # Unix
     export PYTHONPATH="$CONDA_PREFIX/share/qgis/python:$PYTHONPATH"
     export PYTHONPATH="$CONDA_PREFIX/share/qgis/python/plugins:$PYTHONPATH"
-    if [ -d $CONDA_PREFIX/QGIS.app ]; then
-        # OSX also needs these
-        export QGIS_PREFIX_PATH="$CONDA_PREFIX"
-        export QT_PLUGIN_PATH="$CONDA_PREFIX/plugins:$QT_PLUGIN_PATH"
-    fi
+    export QT_PLUGIN_PATH="$CONDA_PREFIX/plugins:$QT_PLUGIN_PATH"
+    # Only needed for OSX (otherwise tries to look in .app), but no harm for Linux
+    export QGIS_PREFIX_PATH="$CONDA_PREFIX"
 elif [ -d $CONDA_PREFIX/Library/python ]; then
     # On Windows
     # See: https://github.com/qgis/QGIS/blob/master/ms-windows/osgeo4w/qgis.vars

--- a/recipe/scripts/deactivate.sh
+++ b/recipe/scripts/deactivate.sh
@@ -17,9 +17,3 @@ if [[ -n "$_CONDA_SET_QT_PLUGIN_PATH" ]]; then
     export QT_PLUGIN_PATH="$_CONDA_SET_QT_PLUGIN_PATH"
     unset _CONDA_SET_QT_PLUGIN_PATH
 fi
-
-unset QGIS_BUNDLE
-if [[ -n "$_CONDA_SET_QGIS_BUNDLE" ]]; then
-    export QGIS_BUNDLE="$_CONDA_SET_QGIS_BUNDLE"
-    unset _CONDA_SET_QGIS_BUNDLE
-fi


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This hopefully fixes startup errors reported by @jakimowb here: https://github.com/conda-forge/qgis-feedstock/pull/154#issuecomment-752043164

I've left the QT_MAC_WANTS_LAYER=1 setting out as I assume that a fix in `qt` is in the works and I'm not sure what it would break. Is this a reasonable assumption or should I be doing this at the same time?

@jakimowb does this seem to be doing the right thing? You can update your `$CONDA_PREFIX/etc/conda/activate.d/qgis-activate.sh` if you want to test...