### PR TITLE
Backport keep pyi files

### DIFF
--- a/.ci_support/linux_64_python3.6.____cpython.yaml
+++ b/.ci_support/linux_64_python3.6.____cpython.yaml
@@ -52,6 +52,8 @@ qt:
 - '5.12'
 qtkeychain:
 - '0.12'
+qwt:
+- '6.1'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/linux_64_python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_python3.7.____cpython.yaml
@@ -52,6 +52,8 @@ qt:
 - '5.12'
 qtkeychain:
 - '0.12'
+qwt:
+- '6.1'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/linux_64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpython.yaml
@@ -52,6 +52,8 @@ qt:
 - '5.12'
 qtkeychain:
 - '0.12'
+qwt:
+- '6.1'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -52,6 +52,8 @@ qt:
 - '5.12'
 qtkeychain:
 - '0.12'
+qwt:
+- '6.1'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/osx_64_python3.6.____cpython.yaml
+++ b/.ci_support/osx_64_python3.6.____cpython.yaml
@@ -52,6 +52,8 @@ qt:
 - '5.12'
 qtkeychain:
 - '0.12'
+qwt:
+- '6.1'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/osx_64_python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_python3.7.____cpython.yaml
@@ -52,6 +52,8 @@ qt:
 - '5.12'
 qtkeychain:
 - '0.12'
+qwt:
+- '6.1'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/osx_64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_python3.8.____cpython.yaml
@@ -52,6 +52,8 @@ qt:
 - '5.12'
 qtkeychain:
 - '0.12'
+qwt:
+- '6.1'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/osx_64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpython.yaml
@@ -52,6 +52,8 @@ qt:
 - '5.12'
 qtkeychain:
 - '0.12'
+qwt:
+- '6.1'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/win_64_python3.6.____cpython.yaml
+++ b/.ci_support/win_64_python3.6.____cpython.yaml
@@ -44,6 +44,8 @@ qt:
 - '5.12'
 qtkeychain:
 - '0.12'
+qwt:
+- '6.1'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/win_64_python3.7.____cpython.yaml
+++ b/.ci_support/win_64_python3.7.____cpython.yaml
@@ -44,6 +44,8 @@ qt:
 - '5.12'
 qtkeychain:
 - '0.12'
+qwt:
+- '6.1'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/win_64_python3.8.____cpython.yaml
+++ b/.ci_support/win_64_python3.8.____cpython.yaml
@@ -44,6 +44,8 @@ qt:
 - '5.12'
 qtkeychain:
 - '0.12'
+qwt:
+- '6.1'
 sqlite:
 - '3'
 target_platform:

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -44,6 +44,8 @@ qt:
 - '5.12'
 qtkeychain:
 - '0.12'
+qwt:
+- '6.1'
 sqlite:
 - '3'
 target_platform:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ source:
     - patches/0008-keep_pyi_files_backport.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py2k]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,9 @@ source:
     - patches/0006-CMakeLists-providers-MDAL-HDF5.patch  # [win]
     # Don't create a .app - just do the usual Unix thing
     - patches/0007-OSX-no-app.patch  # [osx]
+    # Backport keeping pyi files. This is not crucial, but makes easier to create
+    # Developement environments with full autocompletation
+    - patches/0008-keep_pyi_files_backport.patch
 
 build:
   number: 0

--- a/recipe/patches/0008-keep_pyi_files_backport.patch
+++ b/recipe/patches/0008-keep_pyi_files_backport.patch
@@ -1,0 +1,60 @@
+diff --git debian/python3-qgis-common.install debian/python3-qgis-common.install
+index 0c0bb9767f..320f178d59 100644
+--- debian/python3-qgis-common.install
++++ debian/python3-qgis-common.install
+@@ -1,5 +1,5 @@
+ usr/lib/python*/*-packages/PyQt?/uic/widget-plugins/qgis_customwidgets.py
+-usr/lib/python*/*-packages/qgis/*.py
++usr/lib/python*/*-packages/qgis/*.py*
+ usr/lib/python*/*-packages/qgis/PyQt/*
+ usr/lib/python*/*-packages/qgis/processing/*
+ usr/lib/python*/*-packages/qgis/testing/*
+diff --git debian/python3-qgis.install debian/python3-qgis.install
+index 2425a3080d..24e4813935 100644
+--- debian/python3-qgis.install
++++ debian/python3-qgis.install
+@@ -1,10 +1,6 @@
+ usr/lib/python*/*-packages/qgis/3d/__init__.py
+-usr/lib/python*/*-packages/qgis/_3d.so
+-usr/lib/python*/*-packages/qgis/_analysis.so
+-usr/lib/python*/*-packages/qgis/_core.so
+-usr/lib/python*/*-packages/qgis/_gui.so
+-usr/lib/python*/*-packages/qgis/_server.so
+ usr/lib/python*/*-packages/qgis/analysis/__init__.py
+ usr/lib/python*/*-packages/qgis/core/__init__.py
+ usr/lib/python*/*-packages/qgis/gui/__init__.py
+ usr/lib/python*/*-packages/qgis/server/__init__.py
++usr/lib/python*/*-packages/qgis/*.so
+diff --git ms-windows/osgeo4w/package.cmd ms-windows/osgeo4w/package.cmd
+index 32f2c35617..cf34ed6f1e 100644
+--- ms-windows/osgeo4w/package.cmd
++++ ms-windows/osgeo4w/package.cmd
+@@ -332,6 +332,7 @@ if errorlevel 1 (echo tar common failed & goto error)
+ 	"apps/%PACKAGENAME%/resources/server/" ^
+ 	"apps/%PACKAGENAME%/server/" ^
+ 	"apps/%PACKAGENAME%/python/qgis/_server.pyd" ^
++	"apps/%PACKAGENAME%/python/qgis/_server.pyi" ^
+ 	"apps/%PACKAGENAME%/python/qgis/server/" ^
+ 	"httpd.d/httpd_%PACKAGENAME%.conf.tmpl" ^
+ 	"etc/postinstall/%PACKAGENAME%-server.bat" ^
+@@ -367,6 +368,7 @@ if not exist %ARCH%\release\qgis\%PACKAGENAME% mkdir %ARCH%\release\qgis\%PACKAG
+ 	--exclude-from exclude ^
+ 	--exclude "*.pyc" ^
+ 	--exclude "apps/%PACKAGENAME%/python/qgis/_server.pyd" ^
++	--exclude "apps/%PACKAGENAME%/python/qgis/_server.pyi" ^
+ 	--exclude "apps/%PACKAGENAME%/python/qgis/_server.lib" ^
+ 	--exclude "apps/%PACKAGENAME%/python/qgis/server" ^
+ 	--exclude "apps/%PACKAGENAME%/server/" ^
+diff --git python/CMakeLists.txt python/CMakeLists.txt
+index 2e081dc20b..5f1f468d55 100644
+--- python/CMakeLists.txt
++++ python/CMakeLists.txt
+@@ -440,3 +440,8 @@ foreach(module ${PY_MODULES})
+     install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${module}/auto_generated DESTINATION ${SIP_DEFAULT_SIP_DIR}/qgis/${module})
+   endif()
+ endforeach(module)
++
++if((${SIP_VERSION_STR} VERSION_EQUAL 4.18) OR (${SIP_VERSION_STR} VERSION_GREATER 4.18))
++  file(GLOB PY_PYIS ${QGIS_PYTHON_OUTPUT_DIRECTORY}/*.pyi)
++  install(FILES ${PY_PYIS} DESTINATION ${QGIS_PYTHON_DIR})
++endif()


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This is not a crucial patch, nevertheless, keeping the pyi files will allow for some python text editors to use autocomplete
even on classes built on C++ 

This have been done in QGIS Master branch, the current patch kind of backports it to our LTR build