### PR TITLE
Migrate python3.10, gdal3.4, proj8.2, and geos3.10.1 at once

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,18 +8,22 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
+      linux_64_python3.10.____cpython:
+        CONFIG: linux_64_python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_python3.7.____cpython:
         CONFIG: linux_64_python3.7.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_python3.8.____cpython:
         CONFIG: linux_64_python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_python3.9.____cpython:
         CONFIG: linux_64_python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,6 +8,9 @@ jobs:
     vmImage: macOS-10.15
   strategy:
     matrix:
+      osx_64_python3.10.____cpython:
+        CONFIG: osx_64_python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
       osx_64_python3.7.____cpython:
         CONFIG: osx_64_python3.7.____cpython
         UPLOAD_PACKAGES: 'True'

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,6 +8,9 @@ jobs:
     vmImage: vs2017-win2016
   strategy:
     matrix:
+      win_64_python3.10.____cpython:
+        CONFIG: win_64_python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
       win_64_python3.7.____cpython:
         CONFIG: win_64_python3.7.____cpython
         UPLOAD_PACKAGES: 'True'

--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -47,7 +47,7 @@ pin_run_as_build:
 proj:
 - 8.2.0
 python:
-- 3.7.* *_cpython
+- 3.10.* *_cpython
 qt:
 - '5.12'
 qtkeychain:

--- a/.ci_support/linux_64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpython.yaml
@@ -13,15 +13,15 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 exiv2:
 - '0.27'
 expat:
 - '2'
 gdal:
-- '3.3'
+- '3.4'
 geos:
-- 3.10.0
+- 3.10.1
 gsl:
 - '2.7'
 icu:
@@ -45,7 +45,7 @@ pin_run_as_build:
   sqlite:
     max_pin: x
 proj:
-- 8.1.1
+- 8.2.0
 python:
 - 3.8.* *_cpython
 qt:
@@ -59,5 +59,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - cdt_name
-  - docker_image

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -13,15 +13,15 @@ cxx_compiler:
 cxx_compiler_version:
 - '9'
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 exiv2:
 - '0.27'
 expat:
 - '2'
 gdal:
-- '3.3'
+- '3.4'
 geos:
-- 3.10.0
+- 3.10.1
 gsl:
 - '2.7'
 icu:
@@ -45,7 +45,7 @@ pin_run_as_build:
   sqlite:
     max_pin: x
 proj:
-- 8.1.1
+- 8.2.0
 python:
 - 3.9.* *_cpython
 qt:
@@ -59,5 +59,3 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - cdt_name
-  - docker_image

--- a/.ci_support/migrations/gdal34.yaml
+++ b/.ci_support/migrations/gdal34.yaml
@@ -1,0 +1,9 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+gdal:
+- '3.4'
+libgdal:
+- '3.4'
+migrator_ts: 1636499972.7301745

--- a/.ci_support/migrations/geos3100.yaml
+++ b/.ci_support/migrations/geos3100.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-geos:
-- 3.10.0
-migrator_ts: 1634841454.957882

--- a/.ci_support/migrations/geos3101.yaml
+++ b/.ci_support/migrations/geos3101.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+geos:
+- 3.10.1
+migrator_ts: 1635949255.9540627

--- a/.ci_support/migrations/gsl27.yaml
+++ b/.ci_support/migrations/gsl27.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-  check_solvable: false
-gsl:
-- '2.7'
-migrator_ts: 1626373748.7306545

--- a/.ci_support/migrations/proj820.yaml
+++ b/.ci_support/migrations/proj820.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+migrator_ts: 1635805985.4841452
+proj:
+- 8.2.0

--- a/.ci_support/migrations/python310.yaml
+++ b/.ci_support/migrations/python310.yaml
@@ -1,0 +1,33 @@
+migrator_ts: 1634137107
+__migrator:
+    migration_number: 1
+    operation: key_add
+    primary_key: python
+    ordering:
+        python:
+            - 3.6.* *_cpython
+            - 3.7.* *_cpython
+            - 3.8.* *_cpython
+            - 3.9.* *_cpython
+            - 3.10.* *_cpython  # new entry
+            - 3.6.* *_73_pypy
+            - 3.7.* *_73_pypy
+    paused: false
+    longterm: True
+    pr_limit: 40
+    exclude:
+      # this shouldn't attempt to modify the python feedstocks
+      - python
+      - pypy3.6
+      - pypy-meta
+      - cross-python
+      - python_abi
+    exclude_pinned_pkgs: false
+
+python:
+  - 3.10.* *_cpython
+# additional entries to add for zip_keys
+numpy:
+  - 1.21
+python_impl:
+  - cpython

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -1,19 +1,17 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.12'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '9'
-cdt_name:
-- cos6
+- '11'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '9'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '11'
 exiv2:
 - '0.27'
 expat:
@@ -32,6 +30,8 @@ libspatialindex:
 - 1.9.3
 libzip:
 - '1'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 pin_run_as_build:
   gdal:
     max_pin: x.x
@@ -47,7 +47,7 @@ pin_run_as_build:
 proj:
 - 8.2.0
 python:
-- 3.7.* *_cpython
+- 3.10.* *_cpython
 qt:
 - '5.12'
 qtkeychain:
@@ -55,7 +55,7 @@ qtkeychain:
 sqlite:
 - '3'
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_64_python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_python3.7.____cpython.yaml
@@ -17,9 +17,9 @@ exiv2:
 expat:
 - '2'
 gdal:
-- '3.3'
+- '3.4'
 geos:
-- 3.10.0
+- 3.10.1
 gsl:
 - '2.7'
 icu:
@@ -45,7 +45,7 @@ pin_run_as_build:
   sqlite:
     max_pin: x
 proj:
-- 8.1.1
+- 8.2.0
 python:
 - 3.7.* *_cpython
 qt:

--- a/.ci_support/osx_64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_python3.8.____cpython.yaml
@@ -17,9 +17,9 @@ exiv2:
 expat:
 - '2'
 gdal:
-- '3.3'
+- '3.4'
 geos:
-- 3.10.0
+- 3.10.1
 gsl:
 - '2.7'
 icu:
@@ -45,7 +45,7 @@ pin_run_as_build:
   sqlite:
     max_pin: x
 proj:
-- 8.1.1
+- 8.2.0
 python:
 - 3.8.* *_cpython
 qt:

--- a/.ci_support/osx_64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpython.yaml
@@ -17,9 +17,9 @@ exiv2:
 expat:
 - '2'
 gdal:
-- '3.3'
+- '3.4'
 geos:
-- 3.10.0
+- 3.10.1
 gsl:
 - '2.7'
 icu:
@@ -45,7 +45,7 @@ pin_run_as_build:
   sqlite:
     max_pin: x
 proj:
-- 8.1.1
+- 8.2.0
 python:
 - 3.9.* *_cpython
 qt:

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -1,19 +1,11 @@
 c_compiler:
-- gcc
-c_compiler_version:
-- '9'
-cdt_name:
-- cos6
+- vs2017
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
-cxx_compiler_version:
-- '9'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- vs2017
 exiv2:
 - '0.27'
 expat:
@@ -47,7 +39,7 @@ pin_run_as_build:
 proj:
 - 8.2.0
 python:
-- 3.7.* *_cpython
+- 3.10.* *_cpython
 qt:
 - '5.12'
 qtkeychain:
@@ -55,7 +47,4 @@ qtkeychain:
 sqlite:
 - '3'
 target_platform:
-- linux-64
-zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version
+- win-64

--- a/.ci_support/win_64_python3.7.____cpython.yaml
+++ b/.ci_support/win_64_python3.7.____cpython.yaml
@@ -11,9 +11,9 @@ exiv2:
 expat:
 - '2'
 gdal:
-- '3.3'
+- '3.4'
 geos:
-- 3.10.0
+- 3.10.1
 gsl:
 - '2.7'
 icu:
@@ -37,7 +37,7 @@ pin_run_as_build:
   sqlite:
     max_pin: x
 proj:
-- 8.1.1
+- 8.2.0
 python:
 - 3.7.* *_cpython
 qt:

--- a/.ci_support/win_64_python3.8.____cpython.yaml
+++ b/.ci_support/win_64_python3.8.____cpython.yaml
@@ -11,9 +11,9 @@ exiv2:
 expat:
 - '2'
 gdal:
-- '3.3'
+- '3.4'
 geos:
-- 3.10.0
+- 3.10.1
 gsl:
 - '2.7'
 icu:
@@ -37,7 +37,7 @@ pin_run_as_build:
   sqlite:
     max_pin: x
 proj:
-- 8.1.1
+- 8.2.0
 python:
 - 3.8.* *_cpython
 qt:

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -11,9 +11,9 @@ exiv2:
 expat:
 - '2'
 gdal:
-- '3.3'
+- '3.4'
 geos:
-- 3.10.0
+- 3.10.1
 gsl:
 - '2.7'
 icu:
@@ -37,7 +37,7 @@ pin_run_as_build:
   sqlite:
     max_pin: x
 proj:
-- 8.1.1
+- 8.2.0
 python:
 - 3.9.* *_cpython
 qt:

--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,7 @@ bld.bat text eol=crlf
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
 .scripts/* linguist-generated=true
+.woodpecker.yml linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
+              <td>linux_64_python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4674&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qgis-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_64_python3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4674&branchName=master">
@@ -59,6 +66,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_64_python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4674&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qgis-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64_python3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4674&branchName=master">
@@ -77,6 +91,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4674&branchName=master">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qgis-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=4674&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/qgis-feedstock?branchName=master&jobName=win&configuration=win_64_python3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -141,7 +162,8 @@ conda search qgis --channel conda-forge
 About conda-forge
 =================
 
-[![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](http://numfocus.org)
+[![Powered by
+NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org)
 
 conda-forge is a community-led conda channel of installable packages.
 In order to provide high-quality builds, the process has been automated into the

--- a/build-locally.py
+++ b/build-locally.py
@@ -22,6 +22,10 @@ def setup_environment(ns):
         os.environ["MINIFORGE_HOME"] = os.path.join(
             os.path.dirname(__file__), "miniforge3"
         )
+    if "OSX_SDK_DIR" not in os.environ:
+        os.environ["OSX_SDK_DIR"] = os.path.join(
+            os.path.dirname(__file__), "SDKs"
+        )
 
 
 def run_docker_build(ns):

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -97,7 +97,7 @@ requirements:
     - libspatialindex
     - libspatialite
     # For PostgreSQL support.
-    - postgresql
+    - postgresql >=13,<14
     - psycopg2
     # Point Clouds
     - pdal
@@ -126,7 +126,7 @@ requirements:
     - libspatialindex
     - libspatialite
     - psycopg2
-    - postgresql
+    - postgresql >=13,<14
     - exiv2
     - libprotobuf
     # Runtime Python library deps

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - qgisuntwine.patch  # [win]
 
 build:
-  number: 6
+  number: 7
   skip: true  # [py2k or py<37]
 
 requirements:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Due to complexities with `qt` and some workaround done in conda-forge/gdal-feedstock#585, we may need to migrate all four of these at once to get a resolvable dependency path.