### PR TITLE
add libgdal

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -26,6 +26,8 @@ gsl:
 - '2.7'
 icu:
 - '70'
+libgdal:
+- '3.6'
 libprotobuf:
 - '3.21'
 libspatialindex:

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -26,6 +26,8 @@ gsl:
 - '2.7'
 icu:
 - '70'
+libgdal:
+- '3.6'
 libprotobuf:
 - '3.21'
 libspatialindex:

--- a/.ci_support/linux_64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpython.yaml
@@ -26,6 +26,8 @@ gsl:
 - '2.7'
 icu:
 - '70'
+libgdal:
+- '3.6'
 libprotobuf:
 - '3.21'
 libspatialindex:

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -26,6 +26,8 @@ gsl:
 - '2.7'
 icu:
 - '70'
+libgdal:
+- '3.6'
 libprotobuf:
 - '3.21'
 libspatialindex:

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -26,6 +26,8 @@ gsl:
 - '2.7'
 icu:
 - '70'
+libgdal:
+- '3.6'
 libprotobuf:
 - '3.21'
 libspatialindex:

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -26,6 +26,8 @@ gsl:
 - '2.7'
 icu:
 - '70'
+libgdal:
+- '3.6'
 libprotobuf:
 - '3.21'
 libspatialindex:

--- a/.ci_support/osx_64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_python3.8.____cpython.yaml
@@ -26,6 +26,8 @@ gsl:
 - '2.7'
 icu:
 - '70'
+libgdal:
+- '3.6'
 libprotobuf:
 - '3.21'
 libspatialindex:

--- a/.ci_support/osx_64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpython.yaml
@@ -26,6 +26,8 @@ gsl:
 - '2.7'
 icu:
 - '70'
+libgdal:
+- '3.6'
 libprotobuf:
 - '3.21'
 libspatialindex:

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -18,6 +18,8 @@ gsl:
 - '2.7'
 icu:
 - '70'
+libgdal:
+- '3.6'
 libprotobuf:
 - '3.21'
 libspatialindex:

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -18,6 +18,8 @@ gsl:
 - '2.7'
 icu:
 - '70'
+libgdal:
+- '3.6'
 libprotobuf:
 - '3.21'
 libspatialindex:

--- a/.ci_support/win_64_python3.8.____cpython.yaml
+++ b/.ci_support/win_64_python3.8.____cpython.yaml
@@ -18,6 +18,8 @@ gsl:
 - '2.7'
 icu:
 - '70'
+libgdal:
+- '3.6'
 libprotobuf:
 - '3.21'
 libspatialindex:

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -18,6 +18,8 @@ gsl:
 - '2.7'
 icu:
 - '70'
+libgdal:
+- '3.6'
 libprotobuf:
 - '3.21'
 libspatialindex:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0002-skip-dot-in-path.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   #skip: true  # [(not win) or (not py==39)]
   skip: true  # [py2k or py<38]
 
@@ -82,6 +82,7 @@ requirements:
     - qwt
     - qtkeychain
     # GDAL stack.
+    - libgdal
     - gdal
     - geos
     - proj
@@ -109,6 +110,7 @@ requirements:
     - qjson
     - qwt
     - qtkeychain
+    - libgdal
     - gdal
     - geos
     - proj


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Hopefully fixes #276. QGIS links against `libgdal` directly, and also uses the Python bindings (`gdal`). Previously we just had a dependency on `gdal` but I think it also needs to have `libgdal` specified  as it does directly link against it and can't be downgraded.
