### PR TITLE
add LTR branch to abi migration list [skip ci]

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,6 @@
+bot:
+  abi_migration_branches:
+  - LTR
 provider:
   osx: azure
   linux: azure


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Is this ok @SrNetoChan ? Means that the LTR branch will be updated when there is a migration so it is always up to date with the latest set of conda-forge versions (like `main`).
