### PR TITLE
(LTR) [ci skip] ***NO_CI*** Fix duplicate "provider" key in conda-forge.yml

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,6 +4,7 @@ bot:
 provider:
   osx: azure
   linux: azure
+  linux_aarch64: azure
   win: azure
 conda_forge_output_validation: true
 azure:
@@ -21,6 +22,3 @@ build_platform:
   osx_arm64: osx_64
   linux_aarch64: linux_64
 test_on_native_only: true
-provider:
-  linux_aarch64: azure
-


### PR DESCRIPTION
This will fix a bot error and allow the geos 3.11.2 migration to proceed.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* ~[ ] Bumped the build number (if the version is unchanged)~
* ~[ ] Reset the build number to `0` (if the version changed)~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Fixes #308.
