### PR TITLE
Use entrypoints and not .bat files for launching GDAL utils

### DIFF
--- a/.ci_support/migrations/libspatialindex210.yaml
+++ b/.ci_support/migrations/libspatialindex210.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for libspatialindex 2.1.0
-  kind: version
-  migration_number: 1
-libspatialindex:
-- 2.1.0
-migrator_ts: 1734895759.6433609

--- a/recipe/0006-use-entrypoints.patch
+++ b/recipe/0006-use-entrypoints.patch
@@ -1,0 +1,144 @@
+diff -ru QGIS-final-3_40_2_orig/python/plugins/processing/algs/gdal/AssignProjection.py QGIS-final-3_40_2/python/plugins/processing/algs/gdal/AssignProjection.py
+--- QGIS-final-3_40_2_orig/python/plugins/processing/algs/gdal/AssignProjection.py	2024-12-23 13:43:29.783960228 +1000
++++ QGIS-final-3_40_2/python/plugins/processing/algs/gdal/AssignProjection.py	2024-12-23 13:48:50.730411962 +1000
+@@ -110,7 +110,7 @@
+         self.setOutputValue(self.OUTPUT, fileName)
+ 
+         return [
+-            self.commandName() + (".bat" if isWindows() else ".py"),
++            self.commandName(),
+             GdalUtils.escapeAndJoin(arguments),
+         ]
+ 
+diff -ru QGIS-final-3_40_2_orig/python/plugins/processing/algs/gdal/fillnodata.py QGIS-final-3_40_2/python/plugins/processing/algs/gdal/fillnodata.py
+--- QGIS-final-3_40_2_orig/python/plugins/processing/algs/gdal/fillnodata.py	2024-12-23 13:43:29.784960223 +1000
++++ QGIS-final-3_40_2/python/plugins/processing/algs/gdal/fillnodata.py	2024-12-23 13:48:37.138479494 +1000
+@@ -204,6 +204,6 @@
+             arguments.extend(GdalUtils.parseCreationOptions(options))
+ 
+         return [
+-            self.commandName() + (".bat" if isWindows() else ".py"),
++            self.commandName(),
+             GdalUtils.escapeAndJoin(arguments),
+         ]
+diff -ru QGIS-final-3_40_2_orig/python/plugins/processing/algs/gdal/gdal2tiles.py QGIS-final-3_40_2/python/plugins/processing/algs/gdal/gdal2tiles.py
+--- QGIS-final-3_40_2_orig/python/plugins/processing/algs/gdal/gdal2tiles.py	2024-12-23 13:43:29.784960223 +1000
++++ QGIS-final-3_40_2/python/plugins/processing/algs/gdal/gdal2tiles.py	2024-12-23 13:48:31.554507197 +1000
+@@ -283,6 +283,6 @@
+             arguments.extend(input_details.credential_options_as_arguments())
+ 
+         return [
+-            self.commandName() + (".bat" if isWindows() else ".py"),
++            self.commandName(),
+             GdalUtils.escapeAndJoin(arguments),
+         ]
+diff -ru QGIS-final-3_40_2_orig/python/plugins/processing/algs/gdal/gdal2xyz.py QGIS-final-3_40_2/python/plugins/processing/algs/gdal/gdal2xyz.py
+--- QGIS-final-3_40_2_orig/python/plugins/processing/algs/gdal/gdal2xyz.py	2024-12-23 13:43:29.784960223 +1000
++++ QGIS-final-3_40_2/python/plugins/processing/algs/gdal/gdal2xyz.py	2024-12-23 13:48:25.690536262 +1000
+@@ -168,6 +168,6 @@
+             arguments.extend(input_details.credential_options_as_arguments())
+ 
+         return [
+-            self.commandName() + (".bat" if isWindows() else ".py"),
++            self.commandName(),
+             GdalUtils.escapeAndJoin(arguments),
+         ]
+diff -ru QGIS-final-3_40_2_orig/python/plugins/processing/algs/gdal/gdalcalc.py QGIS-final-3_40_2/python/plugins/processing/algs/gdal/gdalcalc.py
+--- QGIS-final-3_40_2_orig/python/plugins/processing/algs/gdal/gdalcalc.py	2024-12-23 13:43:29.784960223 +1000
++++ QGIS-final-3_40_2/python/plugins/processing/algs/gdal/gdalcalc.py	2024-12-23 13:48:20.154563675 +1000
+@@ -462,6 +462,6 @@
+         arguments.append(out)
+ 
+         return [
+-            self.commandName() + (".bat" if isWindows() else ".py"),
++            self.commandName(),
+             GdalUtils.escapeAndJoin(arguments),
+         ]
+diff -ru QGIS-final-3_40_2_orig/python/plugins/processing/algs/gdal/merge.py QGIS-final-3_40_2/python/plugins/processing/algs/gdal/merge.py
+--- QGIS-final-3_40_2_orig/python/plugins/processing/algs/gdal/merge.py	2024-12-23 13:43:29.784960223 +1000
++++ QGIS-final-3_40_2/python/plugins/processing/algs/gdal/merge.py	2024-12-23 13:48:14.090593673 +1000
+@@ -245,6 +245,6 @@
+         arguments.append(list_file)
+ 
+         return [
+-            self.commandName() + (".bat" if isWindows() else ".py"),
++            self.commandName(),
+             GdalUtils.escapeAndJoin(arguments),
+         ]
+diff -ru QGIS-final-3_40_2_orig/python/plugins/processing/algs/gdal/pansharp.py QGIS-final-3_40_2/python/plugins/processing/algs/gdal/pansharp.py
+--- QGIS-final-3_40_2_orig/python/plugins/processing/algs/gdal/pansharp.py	2024-12-23 13:43:29.785960219 +1000
++++ QGIS-final-3_40_2/python/plugins/processing/algs/gdal/pansharp.py	2024-12-23 13:48:07.906624235 +1000
+@@ -174,6 +174,6 @@
+             arguments.append(extra)
+ 
+         return [
+-            self.commandName() + (".bat" if isWindows() else ".py"),
++            self.commandName(),
+             GdalUtils.escapeAndJoin(arguments),
+         ]
+diff -ru QGIS-final-3_40_2_orig/python/plugins/processing/algs/gdal/pct2rgb.py QGIS-final-3_40_2/python/plugins/processing/algs/gdal/pct2rgb.py
+--- QGIS-final-3_40_2_orig/python/plugins/processing/algs/gdal/pct2rgb.py	2024-12-23 13:43:29.785960219 +1000
++++ QGIS-final-3_40_2/python/plugins/processing/algs/gdal/pct2rgb.py	2024-12-23 13:48:00.330661632 +1000
+@@ -119,6 +119,6 @@
+             arguments.extend(input_details.credential_options_as_arguments())
+ 
+         return [
+-            self.commandName() + (".bat" if isWindows() else ".py"),
++            self.commandName(),
+             GdalUtils.escapeAndJoin(arguments),
+         ]
+diff -ru QGIS-final-3_40_2_orig/python/plugins/processing/algs/gdal/polygonize.py QGIS-final-3_40_2/python/plugins/processing/algs/gdal/polygonize.py
+--- QGIS-final-3_40_2_orig/python/plugins/processing/algs/gdal/polygonize.py	2024-12-23 13:43:29.785960219 +1000
++++ QGIS-final-3_40_2/python/plugins/processing/algs/gdal/polygonize.py	2024-12-23 13:47:55.114687351 +1000
+@@ -153,6 +153,6 @@
+             arguments.extend(input_details.credential_options_as_arguments())
+ 
+         return [
+-            self.commandName() + (".bat" if isWindows() else ".py"),
++            self.commandName(),
+             GdalUtils.escapeAndJoin(arguments),
+         ]
+diff -ru QGIS-final-3_40_2_orig/python/plugins/processing/algs/gdal/proximity.py QGIS-final-3_40_2/python/plugins/processing/algs/gdal/proximity.py
+--- QGIS-final-3_40_2_orig/python/plugins/processing/algs/gdal/proximity.py	2024-12-23 13:43:29.785960219 +1000
++++ QGIS-final-3_40_2/python/plugins/processing/algs/gdal/proximity.py	2024-12-23 13:47:50.266711233 +1000
+@@ -271,6 +271,6 @@
+             arguments.extend(input_details.credential_options_as_arguments())
+ 
+         return [
+-            self.commandName() + (".bat" if isWindows() else ".py"),
++            self.commandName(),
+             GdalUtils.escapeAndJoin(arguments),
+         ]
+diff -ru QGIS-final-3_40_2_orig/python/plugins/processing/algs/gdal/retile.py QGIS-final-3_40_2/python/plugins/processing/algs/gdal/retile.py
+--- QGIS-final-3_40_2_orig/python/plugins/processing/algs/gdal/retile.py	2024-12-23 13:43:29.785960219 +1000
++++ QGIS-final-3_40_2/python/plugins/processing/algs/gdal/retile.py	2024-12-23 13:47:43.962742263 +1000
+@@ -294,6 +294,6 @@
+         arguments.extend(credential_options)
+ 
+         return [
+-            self.commandName() + (".bat" if isWindows() else ".py"),
++            self.commandName(),
+             GdalUtils.escapeAndJoin(arguments),
+         ]
+diff -ru QGIS-final-3_40_2_orig/python/plugins/processing/algs/gdal/rgb2pct.py QGIS-final-3_40_2/python/plugins/processing/algs/gdal/rgb2pct.py
+--- QGIS-final-3_40_2_orig/python/plugins/processing/algs/gdal/rgb2pct.py	2024-12-23 13:43:29.785960219 +1000
++++ QGIS-final-3_40_2/python/plugins/processing/algs/gdal/rgb2pct.py	2024-12-23 13:47:38.234770428 +1000
+@@ -112,6 +112,6 @@
+             arguments.extend(input_details.credential_options_as_arguments())
+ 
+         return [
+-            self.commandName() + (".bat" if isWindows() else ".py"),
++            self.commandName(),
+             GdalUtils.escapeAndJoin(arguments),
+         ]
+diff -ru QGIS-final-3_40_2_orig/python/plugins/processing/algs/gdal/sieve.py QGIS-final-3_40_2/python/plugins/processing/algs/gdal/sieve.py
+--- QGIS-final-3_40_2_orig/python/plugins/processing/algs/gdal/sieve.py	2024-12-23 13:43:29.785960219 +1000
++++ QGIS-final-3_40_2/python/plugins/processing/algs/gdal/sieve.py	2024-12-23 13:47:32.482798678 +1000
+@@ -166,6 +166,6 @@
+             arguments.extend(input_details.credential_options_as_arguments())
+ 
+         return [
+-            self.commandName() + (".bat" if isWindows() else ".py"),
++            self.commandName(),
+             GdalUtils.escapeAndJoin(arguments),
+         ]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,10 @@ source:
     # remove when https://github.com/conda-forge/pyqt-feedstock/pull/129 merged
     - 0003-workaround-multi-pyqt5.patch  # [win]
     - 0005-check-locks-not-destroyed.patch
+    - 0006-use-entrypoints.patch 
 
 build:
-  number: 1
+  number: 2
   # pyproj no longer supports py38
   skip: true  # [py2k or py<39]
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Fixes https://github.com/conda-forge/qgis-feedstock/issues/487. Attempted to push this upstream in https://github.com/qgis/QGIS/pull/59953 but they still require older GDAL (without entrypoints). 