### PR TITLE
use libpdal instead of pdal package for dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,10 +13,10 @@ source:
     # remove when https://github.com/conda-forge/pyqt-feedstock/pull/129 merged
     - 0003-workaround-multi-pyqt5.patch  # [win]
     - 0005-check-locks-not-destroyed.patch
-    - 0006-use-entrypoints.patch 
+    - 0006-use-entrypoints.patch
 
 build:
-  number: 2
+  number: 3
   # pyproj no longer supports py38
   skip: true  # [py2k or py<39]
 
@@ -70,7 +70,7 @@ requirements:
     - flex                               # [unix and (build_platform != target_platform)]
     - bison                              # [unix and (build_platform != target_platform)]
     - m4                                 # [unix and (build_platform != target_platform)]
-    - pdal                               # [build_platform != target_platform]
+    - libpdal                            # [build_platform != target_platform]
     - libprotobuf                        # [build_platform != target_platform]
   host:
     - setuptools
@@ -161,7 +161,7 @@ requirements:
     - yaml
     - owslib
     - pyqtwebkit
-    - pdal
+    - libpdal
     - laz-perf
     - ocl-icd      # [linux]
     - khronos-opencl-icd-loader      # [win or osx]


### PR DESCRIPTION
`pdal` brings in a bunch of stuff whereas `libpdal` does not. It is not clear if QGIS needs all of the packages `pdal` provides. This PR sets QGIS' dependency to `libpdal`

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
